### PR TITLE
cloud credentials name changed

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -58,7 +58,7 @@ spec:
             - name: IBMCLOUD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: ibm-cloud-credentials
+                  name: ibm-powervs-cloud-credentials
                   key: ibmcloud_api_key
                   optional: true
           ports:
@@ -106,7 +106,7 @@ spec:
             - name: IBMCLOUD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: ibm-cloud-credentials
+                  name: ibm-powervs-cloud-credentials
                   key: ibmcloud_api_key
                   optional: true
         - name: csi-provisioner

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -46,7 +46,7 @@ spec:
             - name: IBMCLOUD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: ibm-cloud-credentials
+                  name: ibm-powervs-cloud-credentials
                   key: ibmcloud_api_key
                   optional: true
           volumeMounts:


### PR DESCRIPTION
Changed secretRef name from `ibm-cloud-credentials` to `ibm-powervs-cloud-credentials` as that would be appropriate name for `ibm-powervs-block-csi-driver-operator`.