### PR TITLE
Fix the path for the node-update-controller

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -86,7 +86,7 @@ spec:
               cpu: 10m
         - name: node-update-controller
           image: ${DRIVER_IMAGE}
-          command: ["/node-update-controller"]
+          command: ["/bin/node-update-controller"]
           ports:
             - name: metrics
               containerPort: 8081


### PR DESCRIPTION
This will fix the path for the `node-update-controller` command.

depends on https://github.com/openshift/ibm-powervs-block-csi-driver/pull/14