### PR TITLE
OCPBUGS-1801: ibm-powervs-block-csi-driver-controller does not set resource requests

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -109,6 +109,10 @@ spec:
                   name: ibm-powervs-cloud-credentials
                   key: ibmcloud_api_key
                   optional: true
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
[OCPBUGS-1801](https://issues.redhat.com/browse/OCPBUGS-1801): ibm-powervs-block-csi-driver-controller does not set resource requests
/cc @openshift/storage @Madhan-SWE @mkumatag
