### PR TITLE
OCPBUGS-8683: Add management workloads annotations

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -19,6 +19,8 @@ spec:
     metadata:
       labels:
         app: ibm-powervs-block-csi-driver-controller
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       serviceAccountName: ibm-powervs-block-csi-driver-controller-sa

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         app: ibm-powervs-block-csi-driver-node
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       serviceAccount: ibm-powervs-block-csi-driver-node-sa


### PR DESCRIPTION
To support the workload partitioning we need to add the required annotations (openshift/enhancements#703).