### PR TITLE
STOR-1438: Restart controller Pods if metrics-serving-cert changed

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -25,11 +25,12 @@ import (
 
 const (
 	// Operand and operator run in the same namespace
-	defaultNamespace   = "openshift-cluster-csi-drivers"
-	operatorName       = "ibm-powervs-block-csi-driver-operator"
-	operandName        = "ibm-powervs-block-csi-driver"
-	secretName         = "ibm-powervs-block-cloud-credentials"
-	trustedCAConfigMap = "ibm-powervs-block-csi-driver-trusted-ca-bundle"
+	defaultNamespace      = "openshift-cluster-csi-drivers"
+	operatorName          = "ibm-powervs-block-csi-driver-operator"
+	operandName           = "ibm-powervs-block-csi-driver"
+	cloudCredSecretName   = "ibm-powervs-block-cloud-credentials"
+	metricsCertSecretName = "ibm-powervs-block-csi-driver-controller-metrics-serving-cert"
+	trustedCAConfigMap    = "ibm-powervs-block-csi-driver-trusted-ca-bundle"
 )
 
 func RunOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
@@ -119,7 +120,12 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		),
 		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(
 			defaultNamespace,
-			secretName,
+			cloudCredSecretName,
+			secretInformer,
+		),
+		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(
+			defaultNamespace,
+			metricsCertSecretName,
 			secretInformer,
 		),
 		csidrivercontrollerservicecontroller.WithReplicasHook(nodeInformer.Lister()),


### PR DESCRIPTION
Adding `WithSecretHashAnnotationHook()` for `ibm-powervs-block-csi-driver-controller-metrics-serving-cert` ensures that new annotation is published in `ibm-powervs-block-csi-driver-controller` deployment. This, in turn, leads to controller pods restart.

*** Verification ***

Before patch: `oc delete secret -n openshift-cluster-csi-drivers ibm-powervs-block-csi-driver-controller-metrics-serving-cert` doesn't affect the AGE column for `ibm-powervs-block-csi-driver-controller` in the output of `oc get po -n openshift-cluster-csi-drivers`

After patch: After `oc delete secret -n openshift-cluster-csi-drivers ibm-powervs-block-csi-driver-controller-metrics-serving-cert` the AGE column for `ibm-powervs-block-csi-driver-controller` in the output of `oc get po -n openshift-cluster-csi-drivers` is updated and shows very small value (i.e. the controller is automatically restarted as result of re-creating secret)