### PR TITLE
OCPBUGS-25710: snyk: ignore vendor dir

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+exclude:
+  global:
+    - vendor/**


### PR DESCRIPTION
Configuration to ignore the vendor directory while using synk scan.