### PR TITLE
OCPBUGS-28738: Fix 4.16 SAST scan issues for ose-powervs-block-csi-driver-operator-container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/openshift/ibm-powervs-block-csi-driver-operator
 
 go 1.21
 
-toolchain go1.21.3
-
 require (
 	github.com/openshift/api v0.0.0-20240202140003-8b34b9854c7f
 	github.com/openshift/build-machinery-go v0.0.0-20230824093055-6a18da01283c


### PR DESCRIPTION
SAST scan are failing eg: https://cov01.lab.eng.brq2.redhat.com/osh/task/444973/log/stdout.log
```
go: errors parsing go.mod:
/go/src/github.com/openshift/ibm-powervs-block-csi-driver-operator/go.mod:5: unknown directive: toolchain
```